### PR TITLE
[Interface] Version .2: item, gear and spell names are never translated

### DIFF
--- a/WoWChinese/Anniversary/WoWeuCN_Interface/WoWeuCN_Interface.lua
+++ b/WoWChinese/Anniversary/WoWeuCN_Interface/WoWeuCN_Interface.lua
@@ -29,6 +29,50 @@ local WoWeuCN_Interface_PreferredKeys = {
   ["RAID_FINDER"] = 1,
 };
 
+local WoWeuCN_Interface_PatternBlockedKeys = {
+  "TITLE_TEMPLATE",
+  "DECLENSION_SET",
+  "GUILD_TEMPLATE",
+  "GUILD_TITLE_TEMPLATE",
+  "CALL_PET_SPELL_NAME",
+  "ASSIST_ACTION_LOUNGING_PLAYER_NAME",
+  "ASSIST_ACTION_PLAYER_GUARDIAN_NAME",
+  "ASSIST_ACTION_PLAYER_SLAYER_TITLE",
+  "BATTLE_PET_CAGE_ITEM_NAME",
+  "CHALLENGE_MODE_KEYSTONE_NAME",
+};
+
+local WoWeuCN_Interface_NameFontStrings = {
+  "^MerchantItem%d+Name$",
+  "^MerchantBuyBackItemName$",
+  "^LootButton%d+Text$",
+  "^GroupLootFrame%d+Name$",
+  "^SpellButton%d+SpellName$",
+  "^TradePlayerItem%d+Name$",
+  "^TradeRecipientItem%d+Name$",
+  "^QuestInfoRewardsFrameQuestInfoItem%d+Name$",
+  "^QuestInfoSpellObjectiveFrameName$",
+  "^QuestInfoSkillPointFrameName$",
+  "^QuestProgressItem%d+Name$",
+  "^QuestLogItem%d+Name$",
+  "^ActionButton%d+Name$",
+  "^MultiBar%w+Button%d+Name$",
+  "^TradeSkillSkill%d+Text$",
+  "^TradeSkillSkillName$",
+  "^TradeSkillReagent%d+Name$",
+  "^Craft%d+Text$",
+  "^CraftName$",
+  "^CraftReagent%d+Name$",
+  "^ClassTrainerSkill%d+Text$",
+  "^ClassTrainerSkillName$",
+  "^PrimaryProfession%dSpellButton%a+SpellName$",
+  "^SecondaryProfession%dSpellButton%a+SpellName$",
+  "^BrowseButton%d+Name$",
+  "^AuctionsButton%d+Name$",
+  "^BidButton%d+Name$",
+  "^AuctionsItemButtonName$",
+};
+
 local WoWeuCN_Interface_ContextSpecs = {
   { key = "BACKSLOT", roots = {
       ["CharacterFrame"] = true, ["InspectFrame"] = true,
@@ -334,8 +378,15 @@ function WoWeuCN_Interface_BuildReverseMap()
       end
     end
   end
+  local blockedPatternSources = {};
+  for i = 1, #WoWeuCN_Interface_PatternBlockedKeys do
+    local blockedValue = rawget(_G, WoWeuCN_Interface_PatternBlockedKeys[i]);
+    if (type(blockedValue) == "string") then
+      blockedPatternSources[blockedValue] = true;
+    end
+  end
   for original, translated in pairs(WoWeuCN_Interface_Reverse) do
-    if (string.find(original, "%", 1, true)) then
+    if (string.find(original, "%", 1, true) and not blockedPatternSources[original]) then
       WoWeuCN_Interface_AddPatternEntry(original, translated);
     end
   end
@@ -471,6 +522,45 @@ local function WoWeuCN_Interface_IsTitleRegion(fontString)
   return false;
 end
 
+local function WoWeuCN_Interface_IsNameRegion(fontString)
+  local fsName = fontString.GetName and fontString:GetName();
+  if (fsName) then
+    for i = 1, #WoWeuCN_Interface_NameFontStrings do
+      if (string.find(fsName, WoWeuCN_Interface_NameFontStrings[i])) then
+        return true;
+      end
+    end
+  end
+  local parent = fontString:GetParent();
+  if (not parent) then
+    return false;
+  end
+  if ((parent.Name == fontString or parent.Text == fontString) and parent.NameFrame ~= nil) then
+    return true;
+  end
+  if (parent.Name == fontString and (parent.ItemButton or parent.Button or parent.IconFrame or parent.SubName)) then
+    return true;
+  end
+  if (parent.ItemName == fontString) then
+    return true;
+  end
+  if (parent.Text == fontString and parent.IconBorder ~= nil) then
+    return true;
+  end
+  if (parent.name == fontString and (parent.icon or parent.IconBorder)) then
+    return true;
+  end
+  if (parent.Label == fontString and (parent.SkillUps or parent.LockedIcon)) then
+    return true;
+  end
+  if (parent.OutputText == fontString or parent.RecraftingOutputText == fontString
+      or parent.RecipeName == fontString or parent.RecraftRecipeName == fontString
+      or parent.RewardName == fontString) then
+    return true;
+  end
+  return false;
+end
+
 local function WoWeuCN_Interface_TranslateFontString(fontString)
   local text = fontString:GetText();
   if (issecretvalue and issecretvalue(text)) then
@@ -495,7 +585,7 @@ local function WoWeuCN_Interface_TranslateFontString(fontString)
   if (translated == nil) then
     return 0;
   end
-  if (WoWeuCN_Interface_IsTitleRegion(fontString)) then
+  if (WoWeuCN_Interface_IsTitleRegion(fontString) or WoWeuCN_Interface_IsNameRegion(fontString)) then
     return 0;
   end
 

--- a/WoWChinese/Anniversary/WoWeuCN_Interface/WoWeuCN_Interface.toc
+++ b/WoWChinese/Anniversary/WoWeuCN_Interface/WoWeuCN_Interface.toc
@@ -1,6 +1,6 @@
 ## Interface: 20506
 ## Title: WoWeuCN-Interface
-## Version: Anniversary 2.5.6.1
+## Version: Anniversary 2.5.6.2
 ## Notes_en: AddOn translates the game interface (global strings) into Chinese.
 ## Category: Translation
 ## Author: qqytqqyt

--- a/WoWChinese/Classic/WoWeuCN_Interface/WoWeuCN_Interface.lua
+++ b/WoWChinese/Classic/WoWeuCN_Interface/WoWeuCN_Interface.lua
@@ -29,6 +29,50 @@ local WoWeuCN_Interface_PreferredKeys = {
   ["RAID_FINDER"] = 1,
 };
 
+local WoWeuCN_Interface_PatternBlockedKeys = {
+  "TITLE_TEMPLATE",
+  "DECLENSION_SET",
+  "GUILD_TEMPLATE",
+  "GUILD_TITLE_TEMPLATE",
+  "CALL_PET_SPELL_NAME",
+  "ASSIST_ACTION_LOUNGING_PLAYER_NAME",
+  "ASSIST_ACTION_PLAYER_GUARDIAN_NAME",
+  "ASSIST_ACTION_PLAYER_SLAYER_TITLE",
+  "BATTLE_PET_CAGE_ITEM_NAME",
+  "CHALLENGE_MODE_KEYSTONE_NAME",
+};
+
+local WoWeuCN_Interface_NameFontStrings = {
+  "^MerchantItem%d+Name$",
+  "^MerchantBuyBackItemName$",
+  "^LootButton%d+Text$",
+  "^GroupLootFrame%d+Name$",
+  "^SpellButton%d+SpellName$",
+  "^TradePlayerItem%d+Name$",
+  "^TradeRecipientItem%d+Name$",
+  "^QuestInfoRewardsFrameQuestInfoItem%d+Name$",
+  "^QuestInfoSpellObjectiveFrameName$",
+  "^QuestInfoSkillPointFrameName$",
+  "^QuestProgressItem%d+Name$",
+  "^QuestLogItem%d+Name$",
+  "^ActionButton%d+Name$",
+  "^MultiBar%w+Button%d+Name$",
+  "^TradeSkillSkill%d+Text$",
+  "^TradeSkillSkillName$",
+  "^TradeSkillReagent%d+Name$",
+  "^Craft%d+Text$",
+  "^CraftName$",
+  "^CraftReagent%d+Name$",
+  "^ClassTrainerSkill%d+Text$",
+  "^ClassTrainerSkillName$",
+  "^PrimaryProfession%dSpellButton%a+SpellName$",
+  "^SecondaryProfession%dSpellButton%a+SpellName$",
+  "^BrowseButton%d+Name$",
+  "^AuctionsButton%d+Name$",
+  "^BidButton%d+Name$",
+  "^AuctionsItemButtonName$",
+};
+
 local WoWeuCN_Interface_ContextSpecs = {
   { key = "BACKSLOT", roots = {
       ["CharacterFrame"] = true, ["InspectFrame"] = true,
@@ -334,8 +378,15 @@ function WoWeuCN_Interface_BuildReverseMap()
       end
     end
   end
+  local blockedPatternSources = {};
+  for i = 1, #WoWeuCN_Interface_PatternBlockedKeys do
+    local blockedValue = rawget(_G, WoWeuCN_Interface_PatternBlockedKeys[i]);
+    if (type(blockedValue) == "string") then
+      blockedPatternSources[blockedValue] = true;
+    end
+  end
   for original, translated in pairs(WoWeuCN_Interface_Reverse) do
-    if (string.find(original, "%", 1, true)) then
+    if (string.find(original, "%", 1, true) and not blockedPatternSources[original]) then
       WoWeuCN_Interface_AddPatternEntry(original, translated);
     end
   end
@@ -471,6 +522,45 @@ local function WoWeuCN_Interface_IsTitleRegion(fontString)
   return false;
 end
 
+local function WoWeuCN_Interface_IsNameRegion(fontString)
+  local fsName = fontString.GetName and fontString:GetName();
+  if (fsName) then
+    for i = 1, #WoWeuCN_Interface_NameFontStrings do
+      if (string.find(fsName, WoWeuCN_Interface_NameFontStrings[i])) then
+        return true;
+      end
+    end
+  end
+  local parent = fontString:GetParent();
+  if (not parent) then
+    return false;
+  end
+  if ((parent.Name == fontString or parent.Text == fontString) and parent.NameFrame ~= nil) then
+    return true;
+  end
+  if (parent.Name == fontString and (parent.ItemButton or parent.Button or parent.IconFrame or parent.SubName)) then
+    return true;
+  end
+  if (parent.ItemName == fontString) then
+    return true;
+  end
+  if (parent.Text == fontString and parent.IconBorder ~= nil) then
+    return true;
+  end
+  if (parent.name == fontString and (parent.icon or parent.IconBorder)) then
+    return true;
+  end
+  if (parent.Label == fontString and (parent.SkillUps or parent.LockedIcon)) then
+    return true;
+  end
+  if (parent.OutputText == fontString or parent.RecraftingOutputText == fontString
+      or parent.RecipeName == fontString or parent.RecraftRecipeName == fontString
+      or parent.RewardName == fontString) then
+    return true;
+  end
+  return false;
+end
+
 local function WoWeuCN_Interface_TranslateFontString(fontString)
   local text = fontString:GetText();
   if (issecretvalue and issecretvalue(text)) then
@@ -495,7 +585,7 @@ local function WoWeuCN_Interface_TranslateFontString(fontString)
   if (translated == nil) then
     return 0;
   end
-  if (WoWeuCN_Interface_IsTitleRegion(fontString)) then
+  if (WoWeuCN_Interface_IsTitleRegion(fontString) or WoWeuCN_Interface_IsNameRegion(fontString)) then
     return 0;
   end
 

--- a/WoWChinese/Classic/WoWeuCN_Interface/WoWeuCN_Interface.toc
+++ b/WoWChinese/Classic/WoWeuCN_Interface/WoWeuCN_Interface.toc
@@ -1,6 +1,6 @@
 ## Interface: 11509
 ## Title: WoWeuCN-Interface
-## Version: Classic 1.15.9.1
+## Version: Classic 1.15.9.2
 ## Notes_en: AddOn translates the game interface (global strings) into Chinese.
 ## Category: Translation
 ## Author: qqytqqyt

--- a/WoWChinese/MoP/WoWeuCN_Interface/WoWeuCN_Interface.lua
+++ b/WoWChinese/MoP/WoWeuCN_Interface/WoWeuCN_Interface.lua
@@ -29,6 +29,50 @@ local WoWeuCN_Interface_PreferredKeys = {
   ["RAID_FINDER"] = 1,
 };
 
+local WoWeuCN_Interface_PatternBlockedKeys = {
+  "TITLE_TEMPLATE",
+  "DECLENSION_SET",
+  "GUILD_TEMPLATE",
+  "GUILD_TITLE_TEMPLATE",
+  "CALL_PET_SPELL_NAME",
+  "ASSIST_ACTION_LOUNGING_PLAYER_NAME",
+  "ASSIST_ACTION_PLAYER_GUARDIAN_NAME",
+  "ASSIST_ACTION_PLAYER_SLAYER_TITLE",
+  "BATTLE_PET_CAGE_ITEM_NAME",
+  "CHALLENGE_MODE_KEYSTONE_NAME",
+};
+
+local WoWeuCN_Interface_NameFontStrings = {
+  "^MerchantItem%d+Name$",
+  "^MerchantBuyBackItemName$",
+  "^LootButton%d+Text$",
+  "^GroupLootFrame%d+Name$",
+  "^SpellButton%d+SpellName$",
+  "^TradePlayerItem%d+Name$",
+  "^TradeRecipientItem%d+Name$",
+  "^QuestInfoRewardsFrameQuestInfoItem%d+Name$",
+  "^QuestInfoSpellObjectiveFrameName$",
+  "^QuestInfoSkillPointFrameName$",
+  "^QuestProgressItem%d+Name$",
+  "^QuestLogItem%d+Name$",
+  "^ActionButton%d+Name$",
+  "^MultiBar%w+Button%d+Name$",
+  "^TradeSkillSkill%d+Text$",
+  "^TradeSkillSkillName$",
+  "^TradeSkillReagent%d+Name$",
+  "^Craft%d+Text$",
+  "^CraftName$",
+  "^CraftReagent%d+Name$",
+  "^ClassTrainerSkill%d+Text$",
+  "^ClassTrainerSkillName$",
+  "^PrimaryProfession%dSpellButton%a+SpellName$",
+  "^SecondaryProfession%dSpellButton%a+SpellName$",
+  "^BrowseButton%d+Name$",
+  "^AuctionsButton%d+Name$",
+  "^BidButton%d+Name$",
+  "^AuctionsItemButtonName$",
+};
+
 local WoWeuCN_Interface_ContextSpecs = {
   { key = "BACKSLOT", roots = {
       ["CharacterFrame"] = true, ["InspectFrame"] = true,
@@ -334,8 +378,15 @@ function WoWeuCN_Interface_BuildReverseMap()
       end
     end
   end
+  local blockedPatternSources = {};
+  for i = 1, #WoWeuCN_Interface_PatternBlockedKeys do
+    local blockedValue = rawget(_G, WoWeuCN_Interface_PatternBlockedKeys[i]);
+    if (type(blockedValue) == "string") then
+      blockedPatternSources[blockedValue] = true;
+    end
+  end
   for original, translated in pairs(WoWeuCN_Interface_Reverse) do
-    if (string.find(original, "%", 1, true)) then
+    if (string.find(original, "%", 1, true) and not blockedPatternSources[original]) then
       WoWeuCN_Interface_AddPatternEntry(original, translated);
     end
   end
@@ -471,6 +522,45 @@ local function WoWeuCN_Interface_IsTitleRegion(fontString)
   return false;
 end
 
+local function WoWeuCN_Interface_IsNameRegion(fontString)
+  local fsName = fontString.GetName and fontString:GetName();
+  if (fsName) then
+    for i = 1, #WoWeuCN_Interface_NameFontStrings do
+      if (string.find(fsName, WoWeuCN_Interface_NameFontStrings[i])) then
+        return true;
+      end
+    end
+  end
+  local parent = fontString:GetParent();
+  if (not parent) then
+    return false;
+  end
+  if ((parent.Name == fontString or parent.Text == fontString) and parent.NameFrame ~= nil) then
+    return true;
+  end
+  if (parent.Name == fontString and (parent.ItemButton or parent.Button or parent.IconFrame or parent.SubName)) then
+    return true;
+  end
+  if (parent.ItemName == fontString) then
+    return true;
+  end
+  if (parent.Text == fontString and parent.IconBorder ~= nil) then
+    return true;
+  end
+  if (parent.name == fontString and (parent.icon or parent.IconBorder)) then
+    return true;
+  end
+  if (parent.Label == fontString and (parent.SkillUps or parent.LockedIcon)) then
+    return true;
+  end
+  if (parent.OutputText == fontString or parent.RecraftingOutputText == fontString
+      or parent.RecipeName == fontString or parent.RecraftRecipeName == fontString
+      or parent.RewardName == fontString) then
+    return true;
+  end
+  return false;
+end
+
 local function WoWeuCN_Interface_TranslateFontString(fontString)
   local text = fontString:GetText();
   if (issecretvalue and issecretvalue(text)) then
@@ -495,7 +585,7 @@ local function WoWeuCN_Interface_TranslateFontString(fontString)
   if (translated == nil) then
     return 0;
   end
-  if (WoWeuCN_Interface_IsTitleRegion(fontString)) then
+  if (WoWeuCN_Interface_IsTitleRegion(fontString) or WoWeuCN_Interface_IsNameRegion(fontString)) then
     return 0;
   end
 

--- a/WoWChinese/MoP/WoWeuCN_Interface/WoWeuCN_Interface.toc
+++ b/WoWChinese/MoP/WoWeuCN_Interface/WoWeuCN_Interface.toc
@@ -1,6 +1,6 @@
 ## Interface: 50504
 ## Title: WoWeuCN-Interface
-## Version: MoP 5.5.4.1
+## Version: MoP 5.5.4.2
 ## Notes_en: AddOn translates the game interface (global strings) into Chinese.
 ## Category: Translation
 ## Author: qqytqqyt

--- a/WoWChinese/Retail/WoWeuCN_Interface/WoWeuCN_Interface.lua
+++ b/WoWChinese/Retail/WoWeuCN_Interface/WoWeuCN_Interface.lua
@@ -29,6 +29,50 @@ local WoWeuCN_Interface_PreferredKeys = {
   ["RAID_FINDER"] = 1,
 };
 
+local WoWeuCN_Interface_PatternBlockedKeys = {
+  "TITLE_TEMPLATE",
+  "DECLENSION_SET",
+  "GUILD_TEMPLATE",
+  "GUILD_TITLE_TEMPLATE",
+  "CALL_PET_SPELL_NAME",
+  "ASSIST_ACTION_LOUNGING_PLAYER_NAME",
+  "ASSIST_ACTION_PLAYER_GUARDIAN_NAME",
+  "ASSIST_ACTION_PLAYER_SLAYER_TITLE",
+  "BATTLE_PET_CAGE_ITEM_NAME",
+  "CHALLENGE_MODE_KEYSTONE_NAME",
+};
+
+local WoWeuCN_Interface_NameFontStrings = {
+  "^MerchantItem%d+Name$",
+  "^MerchantBuyBackItemName$",
+  "^LootButton%d+Text$",
+  "^GroupLootFrame%d+Name$",
+  "^SpellButton%d+SpellName$",
+  "^TradePlayerItem%d+Name$",
+  "^TradeRecipientItem%d+Name$",
+  "^QuestInfoRewardsFrameQuestInfoItem%d+Name$",
+  "^QuestInfoSpellObjectiveFrameName$",
+  "^QuestInfoSkillPointFrameName$",
+  "^QuestProgressItem%d+Name$",
+  "^QuestLogItem%d+Name$",
+  "^ActionButton%d+Name$",
+  "^MultiBar%w+Button%d+Name$",
+  "^TradeSkillSkill%d+Text$",
+  "^TradeSkillSkillName$",
+  "^TradeSkillReagent%d+Name$",
+  "^Craft%d+Text$",
+  "^CraftName$",
+  "^CraftReagent%d+Name$",
+  "^ClassTrainerSkill%d+Text$",
+  "^ClassTrainerSkillName$",
+  "^PrimaryProfession%dSpellButton%a+SpellName$",
+  "^SecondaryProfession%dSpellButton%a+SpellName$",
+  "^BrowseButton%d+Name$",
+  "^AuctionsButton%d+Name$",
+  "^BidButton%d+Name$",
+  "^AuctionsItemButtonName$",
+};
+
 local WoWeuCN_Interface_ContextSpecs = {
   { key = "BACKSLOT", roots = {
       ["CharacterFrame"] = true, ["InspectFrame"] = true,
@@ -334,8 +378,15 @@ function WoWeuCN_Interface_BuildReverseMap()
       end
     end
   end
+  local blockedPatternSources = {};
+  for i = 1, #WoWeuCN_Interface_PatternBlockedKeys do
+    local blockedValue = rawget(_G, WoWeuCN_Interface_PatternBlockedKeys[i]);
+    if (type(blockedValue) == "string") then
+      blockedPatternSources[blockedValue] = true;
+    end
+  end
   for original, translated in pairs(WoWeuCN_Interface_Reverse) do
-    if (string.find(original, "%", 1, true)) then
+    if (string.find(original, "%", 1, true) and not blockedPatternSources[original]) then
       WoWeuCN_Interface_AddPatternEntry(original, translated);
     end
   end
@@ -471,6 +522,45 @@ local function WoWeuCN_Interface_IsTitleRegion(fontString)
   return false;
 end
 
+local function WoWeuCN_Interface_IsNameRegion(fontString)
+  local fsName = fontString.GetName and fontString:GetName();
+  if (fsName) then
+    for i = 1, #WoWeuCN_Interface_NameFontStrings do
+      if (string.find(fsName, WoWeuCN_Interface_NameFontStrings[i])) then
+        return true;
+      end
+    end
+  end
+  local parent = fontString:GetParent();
+  if (not parent) then
+    return false;
+  end
+  if ((parent.Name == fontString or parent.Text == fontString) and parent.NameFrame ~= nil) then
+    return true;
+  end
+  if (parent.Name == fontString and (parent.ItemButton or parent.Button or parent.IconFrame or parent.SubName)) then
+    return true;
+  end
+  if (parent.ItemName == fontString) then
+    return true;
+  end
+  if (parent.Text == fontString and parent.IconBorder ~= nil) then
+    return true;
+  end
+  if (parent.name == fontString and (parent.icon or parent.IconBorder)) then
+    return true;
+  end
+  if (parent.Label == fontString and (parent.SkillUps or parent.LockedIcon)) then
+    return true;
+  end
+  if (parent.OutputText == fontString or parent.RecraftingOutputText == fontString
+      or parent.RecipeName == fontString or parent.RecraftRecipeName == fontString
+      or parent.RewardName == fontString) then
+    return true;
+  end
+  return false;
+end
+
 local function WoWeuCN_Interface_TranslateFontString(fontString)
   local text = fontString:GetText();
   if (issecretvalue and issecretvalue(text)) then
@@ -495,7 +585,7 @@ local function WoWeuCN_Interface_TranslateFontString(fontString)
   if (translated == nil) then
     return 0;
   end
-  if (WoWeuCN_Interface_IsTitleRegion(fontString)) then
+  if (WoWeuCN_Interface_IsTitleRegion(fontString) or WoWeuCN_Interface_IsNameRegion(fontString)) then
     return 0;
   end
 

--- a/WoWChinese/Retail/WoWeuCN_Interface/WoWeuCN_Interface.toc
+++ b/WoWChinese/Retail/WoWeuCN_Interface/WoWeuCN_Interface.toc
@@ -1,6 +1,6 @@
 ## Interface: 120100
 ## Title: WoWeuCN-Interface
-## Version: 12.1.0.1
+## Version: 12.1.0.2
 ## Notes_en: AddOn translates the game interface (global strings) into Chinese.
 ## Category: Translation
 ## Author: qqytqqyt


### PR DESCRIPTION
Updates WoWeuCN-Interface to version .2 for all four flavors (Retail 12.1.0.2, Classic 1.15.9.2, Anniversary 2.5.6.2, MoP 5.5.4.2).

## Changes

- Item, gear and spell names are never translated any more. They are covered by the dedicated translation addons, and matching them against interface format strings partially translated them and could reverse their word order (names shaped like "X of the Y" were rendered as "Y - X").
- Name-composition format templates (player/guild title templates, pet-call and caged-pet names and similar) are excluded from the format-string pattern engine, on every client language.
- The name display regions of the merchant, loot and group-loot, trade, quest reward, spellbook, class trainer, profession, auction house, Encounter Journal, collection journal and action bar (macro names) frames are left untouched, while their surrounding interface text keeps translating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fsqtmuL9eKByGtLjb4Rst